### PR TITLE
Keyed results

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ client.project("yourBillingProjectId")
 * Alternatively: If you prefer to use your username/password combination directly for each query, then inside  [`start.py`](https://github.com/superquery/superPy/blob/master/examples/start.py) enter your details obtained from the superquery.io web interface where it shows `xxxxxxx` below
 
 ```
-query_job = client.query(
+result = client.query(
     "SELECT field FROM `projectId.datasetId.tableID` WHERE _PARTITIONTIME = \"20xx-xx-xx\"", 
     username="xxxxxxxxx",
     password="xxxxxxxxx")

--- a/superQuery/superQuery.py
+++ b/superQuery/superQuery.py
@@ -130,7 +130,7 @@ class Client(object):
         self._destination_table = None
         self._write_disposition = None
 
-        self.result = None
+        self.last_result = None
         self.connection = None
 
 
@@ -209,8 +209,9 @@ class Client(object):
                     explain = cursor2.fetchall()
                     stats = json.loads(explain[0]["statistics"])
                     #job_reference = json.loads(explain[0]["jobReference"])
-                self.result = Result(cursor, stats)
-                return self.result
+                result = Result(cursor, stats)
+                self.last_result = result
+                return result
 
         except Exception as e:
             self._logger.error("An error occurred (perhaps retry)")
@@ -295,7 +296,3 @@ class Client(object):
             self._logger.exception(e)
             raise
 
-    @property
-    def stats(self):
-        if self.result is not None:
-            return self.result.stats


### PR DESCRIPTION
Results objects can now return a stable key (a Base64 encoded representation of the full table name)

When fetching results based on a key, the initial full table name is set on the new result to ensure key stability.

Permissions for reading/sharing keyed results follow directly from BigQuery permissions. Temporary, anonymous results tables cannot be shared across users.

# Notes

To maintain the same level of abstraction, all interaction with the downstream datastore is conducted via the MySQL connector interface. This has a number of implications and restrictions:
1. You cannot promote anonymous temporary table results to an explicit table readable by other users. You could achieve this by copying the table when required to a shared, readable table but it would require using the BQ libraries directly or enhancing the MySQL connector interface to support this.
2. Similarly, implementing the BQ Storage download table directly from storage shouldn't be implemented alongside the MySQL connector interface, but rather within. On a separate note, this feature is subject to certain restrictions, which are only vaguely documented.

Given the potential need for superQuery to eventually support other databases, implementing these features directly by using the database-specific client libraries creates a future mess and a leaky abstraction. There are already details of the abstraction which have leaked out, specifically concepts that relate directly to BigQuery (dataset id, destination tables, write dispositions), which could benefit from reassessment.

## Issues
### Result should not be an instance variable on Client
This does not constitute part of the state of the Client and effectively means that 
users can only work with one result at a time.

```python
student_names_result = client.query('SELECT name FROM students')
courses_result = client.query('SELECT course_name FROM courses')

for name in student_names_result.result():
  # Iterates over courses!
```

### Client.query swallows errors
If you consider the above example but where the second query results in an error, the error is logged, but execution proceeds and the previous instance of Client.result is returned, leaving the user with no indication of an error and a valid result to use.

### Client.query has multiple return statements in both finally and try
Only one of these statements will actually influence the returned value.

### Consider adopting PEP-8 compliance for variable names
Result metadata contains fields such as `destinationTable`, which should be snake_case.

### Client.stats and Result.stats both refer to Result stats
This is potentially confusing in the sense that given the existence of both a user may reasonably assume that they convey different statistics (perhaps Client accumulates totals), but instead the one returns the other. 
