### PR TITLE
HOTFIX: Catch pyDrive import error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@ from setuptools import setup
 setup(
   name = 'superQuery',         
   packages = ['superQuery'],   
-  version = '2.5',
+  version = '2.6',
   license='MIT',       
   description = 'The Python interface to superQuery',  
   author = 'Eben du Toit',                 
   author_email = 'eben@superquery.io',     
   url = 'https://github.com/superquery/superPy',  
-  download_url = 'https://github.com/superquery/superPy/archive/v2.5.tar.gz',    
+  download_url = 'https://github.com/superquery/superPy/archive/v2.6.tar.gz',    
   keywords = ['DATA', 'SUPERQUERY', 'BIGQUERY'],
   install_requires=[            
       'pymysql',

--- a/superQuery/superQuery.py
+++ b/superQuery/superQuery.py
@@ -6,9 +6,14 @@ import logging
 import pymysql.cursors
 import pandas as pd
 
-from pydrive.auth import GoogleAuth
-from pydrive.drive import GoogleDrive
-from oauth2client.client import GoogleCredentials
+# The pydrive and oauth2 context belongs to the superQuery 
+# export to Jupyter flow
+try:
+    from pydrive.auth import GoogleAuth
+    from pydrive.drive import GoogleDrive
+    from oauth2client.client import GoogleCredentials
+except ImportError:
+    print("[sQ] pyDrive or oauth2 clietn import error.")
 
 
 LOG_DIR = os.getenv("SUPERQUERY_LOGDIR")


### PR DESCRIPTION
# Description

When not in the `superQuery` export to `Jupyter` flow, the pyDrive import isn't needed. Here we catch any errors related to this import.